### PR TITLE
Disable opening the browser with BROWSER='none'.

### DIFF
--- a/src/lib/tello.ts
+++ b/src/lib/tello.ts
@@ -149,10 +149,17 @@ export class Tello {
     return new Promise<Tello>(resolve => {
       this.telloTelemetry.start(withWarp10, warp10Params).then(() => {
         this.hasTelemetry = true;
-        opn('http://127.0.0.1:3000/telemetry.html').then(() => {
+
+        const finish = () => {
           Logger.info('[Tello]', `Telemetry started`);
           resolve(this);
-        });
+        };
+
+        if (process.env.BROWSER === 'none') {
+          finish();
+        } else {
+          opn('http://127.0.0.1:3000/telemetry.html').then(finish);
+        }
       });
     });
   }


### PR DESCRIPTION
Copied this approach from create-react-app, where setting `BROWSER='none'` as an environment variable disables the opening of the browser. In my case, I use multiple browsers for different purposes, so this stops safari getting opened every time when I already have the telemetry open...