### PR TITLE
Working bind on macos

### DIFF
--- a/src/lib/tello.ts
+++ b/src/lib/tello.ts
@@ -73,7 +73,7 @@ export class Tello {
   startStream(): Promise<Tello> {
     return new Promise<Tello>(resolve => {
       this.sendCmd('streamon').then(() => {
-        this.tello_video = createSocket('udp4');
+        this.tello_video = createSocket({ type: 'udp4', reuseAddr: true });
         this.h264encoder_spawn = {
           'command': 'mplayer',
           'args': [ '-gui', '-nolirc', '-fps', '35', '-really-quiet', '-' ]
@@ -304,8 +304,8 @@ export class Tello {
   start(): Promise<Tello> {
     this.myEmitter.setMaxListeners(20);
     return new Promise<Tello>(resolve => {
-      this.UDPClient = createSocket('udp4');
-      this.UDPServer = createSocket('udp4');
+      this.UDPClient = createSocket({ type: 'udp4', reuseAddr: true });
+      this.UDPServer = createSocket({ type: 'udp4', reuseAddr: true });
       this.UDPClient.bind(this.localPort, '0.0.0.0', () => {
         Logger.info('[Tello]', 'connected');
         this.sendCmd('command').then(() => {

--- a/src/lib/tello.ts
+++ b/src/lib/tello.ts
@@ -16,7 +16,7 @@ export class Tello {
   private PORT = 8889;
   private HOST = '192.168.10.1';
   private PORT2 = 8890;
-  private HOST2 = '0.0.0.0';
+  private HOST2 = '192.168.10.2';
   private localPort = 50602;
   private isMock = false;
   private isStreming = false;


### PR DESCRIPTION
I'm using this on macOS and I get weird issues. Without both of the 2 commits in this PR I get the following error:

```
$ cp-cli 'src/www/' 'dist/www/'
2020-05-12T20:21:14.864Z [INFO] [Tello] connected
2020-05-12T20:21:14.869Z [INFO] [Tello] send: command
events.js:292
      throw er; // Unhandled 'error' event
      ^

Error: bind EADDRINUSE 0.0.0.0:8890
    at dgram.js:338:20
    at processTicksAndRejections (internal/process/task_queues.js:85:21)
Emitted 'error' event on Socket instance at:
    at dgram.js:340:14
    at processTicksAndRejections (internal/process/task_queues.js:85:21) {
  errno: -48,
  code: 'EADDRINUSE',
  syscall: 'bind',
  address: '0.0.0.0',
  port: 8890
}
error Command failed with exit code 1.
```

However, I don't know if the solution I found in this PR is actually a good one. I think changing to `reuseAddr: true` makes sense (at least according to the post I read on stackoverflow!), but it seems like hardcoding the IP doesn't make sense, at least to me. I guess it's possible to have multiple devices simultaneously connected to the tello, and so the IP might be different.

But, on macOS, on my machine at least, I can't get the script to bind to `0.0.0.0`.

Sorry, this is part bug report and part PR. Are you running this on macOS? Do you know which version of node you're using?

Another approach might be to add a `.nvmrc` file and a note about which node version to use...